### PR TITLE
fix: actualiza mapeo de transmision

### DIFF
--- a/pipeline_permisos_laserena_2024.py
+++ b/pipeline_permisos_laserena_2024.py
@@ -57,7 +57,7 @@ COMBUSTIBLE_MAP = {
 }
 TRANSMISION_MAP = {
     "mec": "mecánica", "mecanica": "mecánica",
-    "aut": "automática", "automatiza": "automática",
+    "aut": "automática", "automatizada": "automática",
     "automatico": "automática", "automatica": "automática",
     "cvt": "automática"
 }


### PR DESCRIPTION
## Summary
- replace erroneously labeled transmission key `automatiza` with `automatizada`

## Testing
- `python -m py_compile pipeline_permisos_laserena_2024.py`


------
https://chatgpt.com/codex/tasks/task_e_689f63d86d848330a56ec4b0c92bafc0