### PR TITLE
Clarify top-k labels in histogram helper

### DIFF
--- a/pipeline_permisos_laserena_2024.py
+++ b/pipeline_permisos_laserena_2024.py
@@ -131,7 +131,7 @@ def boxplot_legible(s: pd.Series, nombre: str, outpath: Path):
     plt.close(fig)
 
 def hist_legible(s: pd.Series, nombre: str, outpath: Path, bins="auto"):
-    """Histograma con etiquetas solo en Top-3 bins y eje X formateado; recorta al p99."""
+    """Histograma con etiquetas solo en Top-k bins (k controlado por TOPK_LABELS) y eje X formateado; recorta al p99."""
     s = s.dropna()
     if s.empty: return
     p99 = np.percentile(s, 99)
@@ -143,7 +143,7 @@ def hist_legible(s: pd.Series, nombre: str, outpath: Path, bins="auto"):
     ax.grid(True, linestyle=":", alpha=.25)
     if s.max() >= 1_000_000:
         ax.xaxis.set_major_formatter(FuncFormatter(money_fmt))
-    # Top-3 bins
+    # Top-k bins
     counts = list(n)
     if any(counts):
         top_idx = sorted(range(len(counts)), key=lambda i: counts[i], reverse=True)[:TOPK_LABELS]


### PR DESCRIPTION
## Summary
- Update histogram helper to refer to generic Top-k bins with k controlled by TOPK_LABELS
- Update accompanying in-function comment for Top-k bins

## Testing
- `python -m py_compile pipeline_permisos_laserena_2024.py`

------
https://chatgpt.com/codex/tasks/task_e_689f63df1bec8330aaa97b8eabb9c59c