### PR TITLE
Add normalization mappings for pipeline script

### DIFF
--- a/pipeline_permisos_laserena_2024.py
+++ b/pipeline_permisos_laserena_2024.py
@@ -51,6 +51,31 @@ MIN_PERMISO_2024  = int(round(UTM_ENERO_2024 * 0.5))  # = 32333
 VALID_SELLOS = {"verde", "amarillo", "rojo"}
 VALID_COMB   = {"bencina", "diésel", "híbrido", "eléctrico", "gnv", "glp"}
 
+# Mapas de normalización (regex -> valor estándar)
+COMBUSTIBLE_MAP = {
+    r"^gasolina$": "bencina",
+    r"^gas$": "bencina",
+    r"^bencina$": "bencina",
+    r"^petroleo(?: diesel)?$": "diésel",
+    r"^diesel$": "diésel",
+    r"^electrico$": "eléctrico",
+    r"^hibrido$": "híbrido",
+    r"^gnv$": "gnv",
+    r"^glp$": "glp",
+}
+
+TRANSMISION_MAP = {
+    r"^mecanica$": "mecánica",
+    r"^manual$": "mecánica",
+    r"^automat(?:ica)?$": "automática",
+}
+
+EQUIPADO_MAP = {
+    r"^si$": "sí",
+    r"^equipado$": "sí",
+    r"^no$": "no",
+}
+
 
 
 LINE = "─" * 80


### PR DESCRIPTION
## Summary
- Define normalization regex maps for fuel, transmission, and equipment fields
- Prevent NameError and support canonical values during data cleaning

## Testing
- `pytest -q`
- Attempted `pip install -q numpy pandas openpyxl matplotlib` (failed: Cannot connect to proxy)


------
https://chatgpt.com/codex/tasks/task_e_689f6c5516c88330b0874c3f35df5b3a